### PR TITLE
Add MechJeb to all command parts

### DIFF
--- a/GameData/mechjeb4all.cfg
+++ b/GameData/mechjeb4all.cfg
@@ -1,0 +1,8 @@
+//Add the Mechjeb module to all command pods who don't have it
+@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[MechJebCore]]:Final
+{    
+    MODULE
+    {
+        name = MechJebCore
+    }
+}


### PR DESCRIPTION
This is a single small Module Manager patch file which adds MechJeb capabilities to all command parts (both probe cores and capsules) without having to (forget to) attach the MechJeb part.
